### PR TITLE
Correct link for Almannaromur

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-The 23<sup>rd</sup> Nordic Conference on Computational Linguistics (NoDaLiDa 2021) will be held in Reykjavik, Iceland. The conference is a two-day event with one additional day of workshops. The conference takes place at <a href="http://www.ru.is">Reykjavik University</a> and is hosted by <a href="http://www.ru.is">Almannarómur</a>. We are closely monitoring the ongoing pandemic and will update the conference plans (e.g. moving to a virtual or hybrid format) as needed closer to the conference dates.
+The 23<sup>rd</sup> Nordic Conference on Computational Linguistics (NoDaLiDa 2021) will be held in Reykjavik, Iceland. The conference is a two-day event with one additional day of workshops. The conference takes place at <a href="http://www.ru.is">Reykjavik University</a> and is hosted by <a href="https://www.facebook.com/almannaromur">Almannarómur</a>. We are closely monitoring the ongoing pandemic and will update the conference plans (e.g. moving to a virtual or hybrid format) as needed closer to the conference dates.
 
 <!-- Box 
 <div class="box" markdown="1">


### PR DESCRIPTION
It'd be better to use almannaromur.is but the website seems to be down for maintenance so using the almannromur facebook page